### PR TITLE
Add rename functionality

### DIFF
--- a/lsp-common.el
+++ b/lsp-common.el
@@ -10,9 +10,14 @@
 
 (defun lsp--position-to-point (params)
   "Convert Position object in PARAMS to a point."
+  (pos-at-line-col (gethash "line" params) (gethash "character" params)))
+
+;; from http://emacs.stackexchange.com/questions/8082/how-to-get-buffer-position-given-line-number-and-column-number
+(defun pos-at-line-col (l c)
   (save-excursion
-      (goto-char (point-min))
-      (forward-line (gethash "line" params))
-      (+ (line-beginning-position) (gethash "character" params))))
+    (goto-char (point-min))
+    (forward-line l)
+    (move-to-column c)
+    (point)))
 
 (provide 'lsp-common)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -260,10 +260,7 @@ interface Range {
 	      (lsp--point-to-position end)))
 
 (defun lsp--apply-workspace-edits (workspace-edits)
-  ;; (message ":workspace-edit: %s" workspace-edits)
-  (maphash (lambda (k v)
-             (maphash (lambda (key value) (lsp--apply-workspace-edit key value)) v))
-           edits)
+  (maphash (lambda (key value) (lsp--apply-workspace-edit key value)) (gethash "changes" edits))
   )
 
 (defun lsp--apply-workspace-edit (uri edits)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -104,7 +104,7 @@ Optional arguments:
       "Yes"
     "No"))
 
-(defconst lsp--capabilities 
+(defconst lsp--capabilities
   `(("textDocumentSync" . ("Document sync method" .
 			   ((1 , "None")
 			    (2 , "Send full contents")
@@ -144,5 +144,13 @@ Optional arguments:
       (insert str)
       (view-mode 1))
     (switch-to-buffer "lsp-capabilities")))
+
+(defun lsp-rename (newname)
+  "Rename an identifier via the Haskell Refactorer"
+  (interactive "sNew name:")
+  (unless lsp--cur-workspace
+    (user-error "No language server is associated with this buffer"))
+  (lsp--text-document-rename newname)
+  )
 
 (provide 'lsp-mode)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -90,7 +90,8 @@ Optional arguments:
 		     :name "Go Language Server")
 
   (lsp-define-client 'haskell-mode "haskell" 'stdio #'lsp--haskell-get-root
-                   :command '("hie" "--lsp" "-d" "-l" (make-temp-file "hie" nil ".log"))
+                   ;; :command '("hie" "--lsp" "-d" "-l" (make-temp-file "hie" nil ".log"))
+                   :command '("hie" "--lsp" "-d" "-l" "/tmp/hie.log")
                    :name "Haskell Language Server"))
 
 (defconst lsp--sync-type


### PR DESCRIPTION
This introduces the function `lsp--apply-text-edits` which should perhaps be used in one or two other places too, for the formatting response.

I have not done this. as I do not have a means to test.
