### PR TITLE
Fix package descriptor

### DIFF
--- a/lsp-mode-pkg.el
+++ b/lsp-mode-pkg.el
@@ -14,6 +14,6 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 (define-package "lsp" "0.0.1"
-  "Emacs client for Language Server Protocol."
-  '((emacs "25.1"))
+  "Client for Language Server Protocol."
+  '((emacs "25.1") (flycheck "30"))
   :url "https://github.com/vibhavp/emacs-lsp")


### PR DESCRIPTION
- Dependency on flycheck was missing, so byte compilation would fail
- Remove redundant "Emacs" from package description: all elisp packages are for Emacs