### PR TITLE
Make flycheck support rust-agnostic

### DIFF
--- a/lsp-flycheck.el
+++ b/lsp-flycheck.el
@@ -25,7 +25,6 @@
 
 ;;; Code:
 
-(require 'lsp-mode)
 (require 'lsp-notifications)
 (require 'flycheck)
 
@@ -59,19 +58,24 @@ CALLBACK is the status callback passed by Flycheck."
   ;; Disable automatic syntax checks, since lsp-mode will call `flycheck-buffer'
   ;; directly.
   (setq-local flycheck-check-syntax-automatically nil)
-  (setq-local flycheck-checker 'rust-lsp)
-  (add-to-list 'flycheck-checkers 'rust-lsp)
+  (setq-local flycheck-checker 'lsp)
+  (add-to-list 'flycheck-checkers 'lsp)
   (flycheck-mode)
   (add-hook 'lsp-after-diagnostics-hook #'flycheck-buffer))
 
-(flycheck-define-generic-checker 'rust-lsp
-  "A Rust syntax checker using the Rust Language Server (RLS) and
-lsp-mode.
+(flycheck-define-generic-checker 'lsp
+  "A syntax checker using the Language Server Protocol (RLS)
+provided by lsp-mode.
 
-See https://github.com/rust-lang-nursery/rls."
+See https://github.com/vibhavp/emacs-lsp."
   :start #'lsp--flycheck-start
-  :modes 'rust-mode
-  :predicate (lambda () (global-lsp-mode)))
+  :modes 'rust-mode                     ; Need a default mode
+  :predicate (lambda () (not (null global-lsp-mode))))
+
+(defun lsp-flycheck-add-mode (mode)
+  "Add MODE as a valid major-mode for the lsp checker."
+  (unless (flycheck-checker-supports-major-mode-p 'lsp mode)
+    (flycheck-add-mode 'lsp mode)))
 
 (provide 'lsp-flycheck)
 

--- a/lsp-flycheck.el
+++ b/lsp-flycheck.el
@@ -58,8 +58,8 @@ CALLBACK is the status callback passed by Flycheck."
   "Setup Flycheck for use with lsp-mode."
   ;; Disable automatic syntax checks, since lsp-mode will call `flycheck-buffer'
   ;; directly.
-  (setq flycheck-check-syntax-automatically nil
-        flycheck-checker 'rust-lsp)
+  (setq-local flycheck-check-syntax-automatically nil)
+  (setq-local flycheck-checker 'rust-lsp)
   (add-to-list 'flycheck-checkers 'rust-lsp)
   (flycheck-mode)
   (add-hook 'lsp-after-diagnostics-hook #'flycheck-buffer))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -27,6 +27,7 @@
 (require 'lsp-methods)
 (require 'lsp-receive)
 (require 'lsp-send)
+(require 'lsp-flycheck)
 (require 'cl-lib)
 
 (defsubst lsp--make-stdio-connection (name command)
@@ -64,7 +65,8 @@ Optional arguments:
                     :get-root (lsp--assert-type get-root #'functionp)
                     :on-initialize (plist-get args :on-initialize)))
            (t (error "Invalid TYPE for LSP client")))))
-    (puthash mode client lsp--defined-clients)))
+    (puthash mode client lsp--defined-clients)
+    (lsp-flycheck-add-mode mode)))
 
 (defun lsp--rust-get-root ()
   (or (locate-dominating-file default-directory "Cargo.toml")


### PR DESCRIPTION
Flycheck still requires an explicit list of modes, so we can't leave that undefined.

For the moment I've added `python-mode` and `go-mode`, but did not test them.

Should fix #33.