### PR TITLE
Actually create the 'lsp-capabilities' buffer

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -420,7 +420,8 @@ interface Range {
       :contentChanges
       ,(cl-case lsp--server-sync-method
 	 ('incremental lsp--changes)
-	 ('full `[,(lsp--full-change-event)])))))
+	 ('full `[,(lsp--full-change-event)])
+	 ('none `[])))))
   (setq lsp--changes []))
 
 (defun lsp--push-change (change-event)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -158,13 +158,16 @@ Optional arguments:
   (unless lsp--cur-workspace
     (user-error "No language server is associated with this buffer"))
   (let ((str (mapconcat #'lsp--cap-str (reverse (hash-table-keys
-						 (lsp--server-capabilities))) "")))
-    (with-current-buffer (generate-new-buffer-name "lsp-capabilities")
+                                                 (lsp--server-capabilities))) ""))
+        (buffer-name (generate-new-buffer-name "lsp-capabilities"))
+        )
+    (get-buffer-create buffer-name)
+    (with-current-buffer buffer-name
       (view-mode -1)
       (erase-buffer)
       (insert str)
       (view-mode 1))
-    (switch-to-buffer "lsp-capabilities")))
+    (switch-to-buffer buffer-name)))
 
 (provide 'lsp-mode)
 ;;; lsp-mode.el ends here


### PR DESCRIPTION
Nothing would show up for the `lsp-capabilities` command, as it would try to
switch to the buffer for the output, without creating it first.