### PR TITLE
Remove confusing startup java message

### DIFF
--- a/lsp-jls.el
+++ b/lsp-jls.el
@@ -62,7 +62,6 @@ The slash is expected at the end."
 (defun lsp--java-get-root ()
   "TODO: use projectile directory"
   (let ((dir default-directory))
-    (message "getting java root")
     (if (string= dir "/")
         (user-error (concat "Couldn't find java root, using:" dir))
       dir)))


### PR DESCRIPTION
When lsp-global-mode is enabled, a confusing "getting java root"
message appeared regardless of what kind of buffer is currently
open.